### PR TITLE
Fix: 반복 종료 날짜를 기준날짜 이전으로 정하면 잘못 출력되는 오류

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -1,6 +1,5 @@
-import { addDays, getRangeOfDays } from "@/utils/repeat";
+import { addDays, getRangeOfDays, compareDates } from "@/utils/repeat";
 import { storage } from "@/utils/storage";
-import { storedMemoList } from "./getters";
 
 const showModal = (state, payload) => {
   if (payload.type !== "new") {
@@ -42,8 +41,10 @@ const closeModal = (state) => {
 
 const addOneMemo = (state) => {
   const createdAt = new Date().toLocaleString();
+
   const keyArray = state.memoList.map((memo) => memo.key);
   let key = keyArray.length === 0 ? 1 : Math.max(...keyArray) + 1;
+
   const repeatGroupIdArray = state.memoList.map(
     (memo) => memo.customData.repeat.groupId
   );
@@ -74,12 +75,18 @@ const addOneMemo = (state) => {
   if (repeat.isRepeat) {
     if (repeat.term === "daily") {
       const newObj = { ...obj };
-      const repeatNum =
-        repeat.type === "number"
-          ? Number(repeat.repeatCount) - 1
-          : repeat.type === "date"
-          ? getRangeOfDays(newObj.dates, repeat.endDate)
-          : 365;
+
+      let repeatNum = 365;
+      if (repeat.type === "number") {
+        repeatNum = Number(repeat.repeatCount) - 1;
+      } else if (repeat.type === "date") {
+        if (compareDates(newObj.dates, repeat.endDate) === true) {
+          repeatNum = getRangeOfDays(newObj.dates, repeat.endDate);
+        } else {
+          repeatNum = 0;
+        }
+      }
+
       for (let i = 0; i < repeatNum; i++) {
         newObj.key++;
         let myDate = new Date(newObj.dates);

--- a/src/utils/repeat.js
+++ b/src/utils/repeat.js
@@ -9,3 +9,9 @@ export const getRangeOfDays = (currentDate, endDate) => {
   const secondDate = new Date(endDate);
   return Math.round(Math.abs((firstDate - secondDate) / oneDay));
 };
+
+export const compareDates = (currentDate, endDate) => {
+  const firstDate = new Date(currentDate);
+  const secondDate = new Date(endDate);
+  return firstDate < secondDate;
+};


### PR DESCRIPTION
https://github.com/jungjaedev/scheduler/issues/23#issue-1518088081

비교함수를 통해 이전 날짜 선택 시 당일만 저장되도록 수정